### PR TITLE
Fixes Issue #3

### DIFF
--- a/src/main/java/de/siphalor/mousewheelie/client/mixin/MixinRecipeBookGui.java
+++ b/src/main/java/de/siphalor/mousewheelie/client/mixin/MixinRecipeBookGui.java
@@ -29,15 +29,20 @@ public abstract class MixinRecipeBookGui implements IRecipeBookGui {
 
 	@Shadow private int parentHeight;
 
+	@Shadow public abstract boolean isOpen();
+
 	@Override
 	public boolean mouseWheelie_scrollRecipeBook(double mouseX, double mouseY, double scrollAmount) {
+		if(!this.isOpen())
+			return false;
 		int top = (this.parentHeight - 166) / 2;
 		if(mouseY < top || mouseY >= top + 166)
 			return false;
 		int left = (this.parentWidth - 147) / 2 - this.leftOffset;
 		if(mouseX >= left && mouseX < left + 147) {
 			// Ugly approach since assigning the casted value causes a runtime mixin error
-			((RecipeBookGuiResultsAccessor) recipesArea).setCurrentPage(MathHelper.clamp((int) (((RecipeBookGuiResultsAccessor) recipesArea).getCurrentPage() + Math.round(scrollAmount * Core.scrollFactor)), 0, ((RecipeBookGuiResultsAccessor) recipesArea).getPageCount() - 1));
+			int maxPage = ((RecipeBookGuiResultsAccessor) recipesArea).getPageCount() - 1;
+			((RecipeBookGuiResultsAccessor) recipesArea).setCurrentPage(MathHelper.clamp((int) (((RecipeBookGuiResultsAccessor) recipesArea).getCurrentPage() + Math.round(scrollAmount * Core.scrollFactor)), 0, maxPage < 0 ? 0 : maxPage));
 			((RecipeBookGuiResultsAccessor) recipesArea).callRefreshResultButtons();
 			return true;
 		} else if(mouseX >= left - 30 && mouseX < left) {


### PR DESCRIPTION
This crash occurs when the player hasn't opened the recipe book or has no unlocked recipes and scrolls over a slot roughly under the player.

When the player hasn't opened the recipe book mouse wheelie will still attempt to scroll between recipe book pages when the mouse is within a given area, this causes a crash as the recipe list hasn't been initalised ( as the book has not been opened ), However if the player made it past this crash and has no recipes then the mod will attempt to set the current page to -1 which also causes a crash in vanilla's logic.

This PR fixes both of the issues mentioned above. If the code is not in your style then feel free to make changes to it.