### PR TITLE
Ignore fake slots

### DIFF
--- a/src/main/java/de/siphalor/mousewheelie/client/inventory/SlotHelper.java
+++ b/src/main/java/de/siphalor/mousewheelie/client/inventory/SlotHelper.java
@@ -1,0 +1,23 @@
+package de.siphalor.mousewheelie.client.inventory;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.screen.slot.Slot;
+
+@Environment(EnvType.CLIENT)
+public class SlotHelper {
+
+	private SlotHelper() {
+	}
+
+	/**
+	 * Returns if the given slot is likely a fake slot and doesn't actually have a real inventory.
+	 */
+	public static boolean isFakeSlot(Slot slot) {
+		// The inventory is likely only null if a mod completely overrides it,
+		// and if it's not null, and has size 0, it's very very likely to not
+		// be a real slot.
+		return slot.inventory == null || slot.inventory.size() == 0;
+	}
+
+}

--- a/src/main/java/de/siphalor/mousewheelie/client/mixin/gui/screen/MixinAbstractContainerScreen.java
+++ b/src/main/java/de/siphalor/mousewheelie/client/mixin/gui/screen/MixinAbstractContainerScreen.java
@@ -2,6 +2,7 @@ package de.siphalor.mousewheelie.client.mixin.gui.screen;
 
 import de.siphalor.mousewheelie.MouseWheelie;
 import de.siphalor.mousewheelie.client.inventory.ContainerScreenHelper;
+import de.siphalor.mousewheelie.client.inventory.SlotHelper;
 import de.siphalor.mousewheelie.client.inventory.sort.InventorySorter;
 import de.siphalor.mousewheelie.client.inventory.sort.SortMode;
 import de.siphalor.mousewheelie.client.network.InteractionManager;
@@ -53,6 +54,9 @@ public abstract class MixinAbstractContainerScreen extends Screen implements ICo
 		if (button == 0) {
 			Slot hoveredSlot = getSlotAt(x2, y2);
 			if (hoveredSlot != null) {
+				if (SlotHelper.isFakeSlot(hoveredSlot)) {
+					return;
+				}
 				boolean alt = hasAltDown();
 				boolean ctrl = hasControlDown();
 				boolean shift = hasShiftDown();
@@ -89,6 +93,10 @@ public abstract class MixinAbstractContainerScreen extends Screen implements ICo
 		if (button == 0) {
 			Slot hoveredSlot = getSlotAt(x, y);
 			if (hoveredSlot != null) {
+				if (SlotHelper.isFakeSlot(hoveredSlot)) {
+					return;
+				}
+
 				boolean alt = hasAltDown();
 				boolean ctrl = hasControlDown();
 				boolean shift = hasShiftDown();
@@ -124,8 +132,11 @@ public abstract class MixinAbstractContainerScreen extends Screen implements ICo
 	@Override
 	public ScrollAction mouseWheelie_onMouseScroll(double mouseX, double mouseY, double scrollAmount) {
 		if (MouseWheelie.CONFIG.scrolling.enable) {
-			if (hasAltDown()) return ScrollAction.FAILURE;
 			Slot hoveredSlot = getSlotAt(mouseX, mouseY);
+			if (hoveredSlot != null && SlotHelper.isFakeSlot(hoveredSlot)) {
+				return ScrollAction.PASS;
+			}
+			if (hasAltDown()) return ScrollAction.FAILURE;
 			if (hoveredSlot == null)
 				return ScrollAction.PASS;
 			if (hoveredSlot.getStack().isEmpty())
@@ -155,6 +166,9 @@ public abstract class MixinAbstractContainerScreen extends Screen implements ICo
 	public boolean mouseWheelie_triggerSort() {
 		if (focusedSlot == null)
 			return false;
+		if (SlotHelper.isFakeSlot(focusedSlot)) {
+			return false;
+		}
 		if (playerInventory.player.abilities.creativeMode && (!focusedSlot.getStack().isEmpty() == playerInventory.getCursorStack().isEmpty()))
 			return false;
 		InventorySorter sorter = new InventorySorter(handler, focusedSlot);


### PR DESCRIPTION
While it may seem to work at first, the problem with considering these slots is that it's impossible to decide whether they belong to the same inventory or not. The effect is that slots that make up the 3x3 crafting grid in the terminal are regarded the same as the player inventory (since both use the same, empty fake inventory).

Fixes #83
Fixes #82
