### PR TITLE
Fix bounding boxes of creative menu tabs

### DIFF
--- a/src/main/java/de/siphalor/mousewheelie/client/mixin/gui/screen/MixinCreativeInventoryScreen.java
+++ b/src/main/java/de/siphalor/mousewheelie/client/mixin/gui/screen/MixinCreativeInventoryScreen.java
@@ -37,12 +37,10 @@ public abstract class MixinCreativeInventoryScreen extends AbstractInventoryScre
 
 	@Override
 	public ScrollAction mouseWheelie_onMouseScrolledSpecial(double mouseX, double mouseY, double scrollAmount) {
-		boolean overTabs;
-		if (FabricLoader.getInstance().isModLoaded("roughlyenoughitems")) {
-			overTabs = mouseX >= this.x && mouseX < this.x + this.width && ((mouseY >= this.y - 28 && mouseY < this.y + 4) || (mouseY >= this.y + this.height - 4 && mouseY < this.y + this.height + 28));
-		} else {
-			overTabs = mouseY < this.y + 4 || mouseY >= this.y + this.height - 4;
-		}
+		boolean yOverTopTabs = (this.y - 32 <= mouseY && mouseY <= this.y);
+		boolean yOverBottomTabs = (this.y + this.backgroundHeight <= mouseY && mouseY <= this.y + this.backgroundHeight + 32);
+		boolean overTabs = (this.x <= mouseX && mouseX <= this.x + this.backgroundWidth) && (yOverTopTabs || yOverBottomTabs);
+
 		if (overTabs) {
 			if (FabricLoader.getInstance().isModLoaded("fabric") || FabricLoader.getInstance().isModLoaded("fabric-item-groups")) {
 				FabricCreativeGuiHelper helper = new FabricCreativeGuiHelper((CreativeInventoryScreen) (Object) this);


### PR DESCRIPTION
Partial fix for https://github.com/Siphalor/mouse-wheelie/issues/92

Felt stupid debugging this, it's actually super easy once figured out, so I'll leave some documentation here:

Definition: GUI coordinates are on-screen pixel coordinates divided by GUI scale.

- `(this.x, this.y)` are the GUI coordinates of the top-left corner of the inventory screen without the tabs
- `(this.width, this.height)` is the _total_ GUI screen size, e.g. (640, 360) for 1920x1080 resolution with GUI scale 3
- `(this.backgroundWidth, this.backgroundHeight)` is the inventory screen size in pixels

Since GUI coordinates get divided by the GUI scale and the inventory screen gets upscaled by GUI scale, this is also exactly the GUI size of the inventory screen, therefore
- `(this.x + this.backgroundWidth, this.y + this.backgroundHeight)` is the bottom-right GUI coordinate of the inventory screen (without the tabs)

Creative tabs are exactly 32 pixels high, despite looking smaller. There's some hover text and they are still clickable in that area, so I removed the `+ 4`, `- 4` adjustments.

There is no need for any extra work for REI as it doesn't change the coordinates and there's no overlap from what I can tell.
