### PR TITLE
fix: make InteractionManager's executor thread a daemon

### DIFF
--- a/src/main/java/de/siphalor/mousewheelie/client/network/InteractionManager.java
+++ b/src/main/java/de/siphalor/mousewheelie/client/network/InteractionManager.java
@@ -42,7 +42,12 @@ import net.minecraft.world.inventory.ContainerInput;
 @CustomLog
 public class InteractionManager {
 	private static final Queue<InteractionEvent> interactionEventQueue = new ArrayDeque<>();
-	private static final ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(1);
+	private static final ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(1, runnable -> {
+		Thread thread = new Thread(runnable, "Mouse Wheelie Interaction Manager");
+		// Daemon, so that this executor never keeps the JVM alive after the game shuts down.
+		thread.setDaemon(true);
+		return thread;
+	});
 	private static ScheduledFuture<?> tickFuture;
 
 


### PR DESCRIPTION
Fixes #291.

`InteractionManager` constructed its `ScheduledThreadPoolExecutor` without a `ThreadFactory`, so it fell back to `Executors.defaultThreadFactory()`, which creates **non-daemon** threads. The executor is never shut down, so that one thread kept the JVM alive after the game had finished shutting down. Two symptoms followed:

- Minecraft's `ClientShutdownWatchdog` wrote a "Client shutdown from post-main" crash report on every exit.
- The process lingered. Under Prism Launcher that blocks relaunching the instance until it's killed by hand.

This gives the executor a factory that produces a named daemon thread. Naming it also means it shows up identifiably in thread dumps instead of an anonymous `pool-N-thread-1`.

### Testing

Built from this branch with Gradle 9.4.1 / JDK 25 and installed in place of the 1.16.3 release on a Minecraft 26.2 instance (179 mods, nothing else changed):

- Mouse Wheelie behaves identically - scrolling items between inventory and containers, and sorting, both work as before.
- The client exits with code 0 and writes no crash report. Same instance before the change: code 248 plus a crash report every time.

Verified in the compiled output that the constructor is now `ScheduledThreadPoolExecutor.<init>:(ILjava/util/concurrent/ThreadFactory;)` with `setDaemon(true)` on the created thread.
