### PR TITLE
add config  to disable or enable auto refil bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ bin/
 # fabric
 
 run/
+
+*.DS_Store

--- a/src/main/java/de/siphalor/mousewheelie/MWConfig.java
+++ b/src/main/java/de/siphalor/mousewheelie/MWConfig.java
@@ -131,6 +131,9 @@ public class MWConfig {
 		public boolean use = true;
 		public boolean other = true;
 
+		// Refill exclusions
+		public boolean ignoreBuckets = false;
+
 		public Rules rules = new Rules();
 
 		@CompoundWeaving

--- a/src/main/java/de/siphalor/mousewheelie/client/inventory/SlotRefiller.java
+++ b/src/main/java/de/siphalor/mousewheelie/client/inventory/SlotRefiller.java
@@ -132,6 +132,9 @@ public class SlotRefiller {
 		if (isRefillInProgress()) {
 			return;
 		}
+		if (MouseWheelie.config.refill.ignoreBuckets && stack.getItem() instanceof BucketItem) {
+			return;
+		}
 		//# if MC_VERSION_NUMBER >= 12101
 		if (!stack.getOrDefault(
 				EnchantmentEffectComponents.TRIDENT_RETURN_ACCELERATION,

--- a/src/main/resources/assets/mousewheelie/lang/en_us.json
+++ b/src/main/resources/assets/mousewheelie/lang/en_us.json
@@ -100,6 +100,8 @@
     "mousewheelie.config.refill.use.description": "Refill when using up items, like tools or weapons.",
     "mousewheelie.config.refill.other": "Refill on other occasions",
     "mousewheelie.config.refill.other.description": "Refill on other occasions.",
+    "mousewheelie.config.refill.ignore-buckets": "Ignore buckets",
+    "mousewheelie.config.refill.ignore-buckets.description": "Never refill buckets (e.g. empty, water and lava buckets).\nThis prevents accidentally placing fluids after emptying or filling a bucket.",
     "mousewheelie.config.refill.rules": "Refill rules",
     "mousewheelie.config.refill.rules.description": "Configure with which new item the previous stack will be refilled.",
     "mousewheelie.config.refill.rules.any-block": "Refill with any blocks",


### PR DESCRIPTION
Add config 'Ignore buckets' in Refill item

It will never refill bucktest (empty, water, and lava buckets)
This prevents accidentally placing fluids after emptying or filling a bucket.

<img width="1792" height="1269" alt="image" src="https://github.com/user-attachments/assets/e79644f7-8631-425b-b94c-1266448b4daf" />
